### PR TITLE
Component: fix invalidate() method compatibility for OpenFL 8 and newer

### DIFF
--- a/minimalcomps/components/Component.hx
+++ b/minimalcomps/components/Component.hx
@@ -97,7 +97,7 @@ class Component extends Sprite {
     /**
      * Marks the component to be redrawn on the next frame.
      */
-    private function invalidate():Void {
+	#if (openfl >= "8.0.0") override public #else private #end function invalidate():Void {
         if (_invalidated) 
             return;
 


### PR DESCRIPTION
The invalidate() method didn't exist in older versions of OpenFL. Now, it needs to be overridden.